### PR TITLE
Refactor appliance_setup::apache

### DIFF
--- a/puppet/modules/appliance_components/manifests/ajp.pp
+++ b/puppet/modules/appliance_components/manifests/ajp.pp
@@ -1,0 +1,12 @@
+# Class: appliance_components::ajp
+#
+# This class installs and configures ajp for Apache.
+#
+# Requires: appliance_components::apache
+#
+class appliance_components::ajp {
+  include appliance_components::apache
+  include ::apache::mod::proxy
+  include ::apache::mod::proxy_http
+  apache::mod { 'proxy_ajp': }
+}

--- a/puppet/modules/appliance_components/manifests/apache.pp
+++ b/puppet/modules/appliance_components/manifests/apache.pp
@@ -8,9 +8,6 @@
 class appliance_components::apache {
   include ::apache
   include ::apache::mod::ssl
-  include ::apache::mod::proxy
-  include ::apache::mod::proxy_http
-  apache::mod { 'proxy_ajp': }
   apache::mod { 'rewrite': }
 
   file { '/etc/apache2/sites-enabled/default-ssl':

--- a/puppet/modules/appliance_components/manifests/kenyaemr.pp
+++ b/puppet/modules/appliance_components/manifests/kenyaemr.pp
@@ -5,12 +5,12 @@
 #
 # Requires:
 #
-#  appliance_components::apache
+#  appliance_components::ajp
 #  appliance_components::mysql
 #  appliance_components::tomcat
 #
 class appliance_components::kenyaemr {
-  include appliance_components::apache
+  include appliance_components::ajp
   include appliance_components::mysql
   include appliance_components::tomcat
 


### PR DESCRIPTION
breaking out proxy and ajp specifics from apache so we don't include them by default unless needed.
